### PR TITLE
Refactor and improve CARGO_HOME support

### DIFF
--- a/cmake/CMakeDetermineRustCompiler.cmake
+++ b/cmake/CMakeDetermineRustCompiler.cmake
@@ -9,7 +9,7 @@ if(NOT CMAKE_Rust_COMPILER)
 	endif()
 endif()
 
-message(STATUS "Cargo Prefix: ${CARGO_PREFIX}")
+message(STATUS "Cargo Home: ${CARGO_HOME}")
 message(STATUS "Rust Compiler Version: ${RUSTC_VERSION}")
 
 mark_as_advanced(CMAKE_Rust_COMPILER)

--- a/cmake/FindRust.cmake
+++ b/cmake/FindRust.cmake
@@ -4,59 +4,53 @@ set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM BOTH)
 set(_CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ${CMAKE_FIND_ROOT_PATH_MODE_INCLUDE})
 set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE BOTH)
 
-if ("$ENV{CARGO_HOME}" STREQUAL "")
-	if(WIN32)
-		set(USER_HOME "$ENV{USERPROFILE}")
-	else()
-		set(USER_HOME "$ENV{HOME}")
-	endif()
-
-	# Find cargo prefix
-	find_path(CARGO_PREFIX ".cargo"
-		PATHS "${USER_HOME}")
+if(CMAKE_HOST_WIN32)
+	set(USER_HOME "$ENV{USERPROFILE}")
 else()
-	set(CARGO_PREFIX "$ENV{CARGO_HOME}")
+	set(USER_HOME "$ENV{HOME}")
 endif()
 
-if(CARGO_PREFIX MATCHES "NOTFOUND")
-	message(FATAL_ERROR "Could not find Rust!")
-else()
-	set(CARGO_PREFIX "${CARGO_PREFIX}/.cargo")
+if(NOT DEFINED CARGO_HOME)
+	if("$ENV{CARGO_HOME}" STREQUAL "")
+		set(CARGO_HOME "${USER_HOME}/.cargo")
+	else()
+		set(CARGO_HOME "$ENV{CARGO_HOME}")
+	endif()
 endif()
 
 # Find cargo executable
 find_program(CARGO_EXECUTABLE cargo
-	HINTS "${CARGO_PREFIX}"
+	HINTS "${CARGO_HOME}"
 	PATH_SUFFIXES "bin")
 mark_as_advanced(CARGO_EXECUTABLE)
 
 # Find rustc executable
 find_program(RUSTC_EXECUTABLE rustc
-	HINTS "${CARGO_PREFIX}"
+	HINTS "${CARGO_HOME}"
 	PATH_SUFFIXES "bin")
 mark_as_advanced(RUSTC_EXECUTABLE)
 
 # Find rustdoc executable
 find_program(RUSTDOC_EXECUTABLE rustdoc
-	HINTS "${CARGO_PREFIX}"
+	HINTS "${CARGO_HOME}"
 	PATH_SUFFIXES "bin")
 mark_as_advanced(RUSTDOC_EXECUTABLE)
 
 # Find rust-gdb executable
 find_program(RUST_GDB_EXECUTABLE rust-gdb
-	HINTS "${CARGO_PREFIX}"
+	HINTS "${CARGO_HOME}"
 	PATH_SUFFIXES "bin")
 mark_as_advanced(RUST_GDB_EXECUTABLE)
 
 # Find rust-lldb executable
 find_program(RUST_LLDB_EXECUTABLE rust-lldb
-	HINTS "${CARGO_PREFIX}"
+	HINTS "${CARGO_HOME}"
 	PATH_SUFFIXES "bin")
 mark_as_advanced(RUST_LLDB_EXECUTABLE)
 
 # Find rustup executable
 find_program(RUSTUP_EXECUTABLE rustup
-	HINTS "${CARGO_PREFIX}"
+	HINTS "${CARGO_HOME}"
 	PATH_SUFFIXES "bin")
 mark_as_advanced(RUSTUP_EXECUTABLE)
 
@@ -65,7 +59,7 @@ set(RUST_FOUND FALSE CACHE INTERNAL "")
 if(CARGO_EXECUTABLE AND RUSTC_EXECUTABLE AND RUSTDOC_EXECUTABLE)
 	set(RUST_FOUND TRUE CACHE INTERNAL "")
 
-	set(CARGO_PREFIX "${CARGO_PREFIX}" CACHE PATH "Rust Cargo prefix")
+	set(CARGO_HOME "${CARGO_HOME}" CACHE PATH "Rust Cargo Home")
 
 	execute_process(COMMAND ${RUSTC_EXECUTABLE} --version OUTPUT_VARIABLE RUSTC_VERSION OUTPUT_STRIP_TRAILING_WHITESPACE)
 	string(REGEX REPLACE "rustc ([^ ]+) .*" "\\1" RUSTC_VERSION "${RUSTC_VERSION}")


### PR DESCRIPTION
Refactor to use the standard CARGO_HOME variable instead of "CARGO_PREFIX". Accept CARGO_HOME as cmake parameter and as an environment variable, and default to "$HOME/.cargo".

@mlfaw these are the improvements I mentioned in your last PR